### PR TITLE
add `hide-display-name-styles`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Place the following into Vencord's QuickCSS:
 
 	--\\--hide-nameplates: true;
 	--\\--hide-guild-tags: true;
+	--\\--hide-display-name-styles: true;
 	--\\--hide-profile-effects: true;
 	--\\--hide-avatar-decorations: false;
 	--\\--hide-gradient-glow-usernames: true;

--- a/import.css
+++ b/import.css
@@ -152,6 +152,15 @@
 	}
 }
 
+@container style(--\\--hide-display-name-styles: true) {
+	[class*=headerText] > [class*=username],
+	[class*=repliedMessage] > [class*=username],
+	[class*=nicknameWithDisplayNameStyles] {
+		font-family: inherit;
+		letter-spacing: inherit;
+	}
+}
+
 @container style(--\\--hide-profile-effects: true) {
 	[class*="profileEffects"] { display: none; }
 }


### PR DESCRIPTION
Hides annoying "display name style" feature in messages, replies, message seach results, profile popups and profile modals.